### PR TITLE
Problème de lien vers page publique

### DIFF
--- a/lyon1-m2/2017/projets.html
+++ b/lyon1-m2/2017/projets.html
@@ -304,7 +304,7 @@
 <h3>Groupe 3: Air Traffic Visualization</h3>
 <img src="project-thumbails/groupe3.gif" alt="Aperçu du projet dataviz du groupe 3"/>
 - <a href="https://github.com/Theguael/dataviz">Projet github</a> 
-- <a href="https://theguael.github.io/">Page publique du projet</a> 
+- <a href="https://theguael.herokuapp.com/viz/">Page publique du projet</a> 
 - <a href="https://github.com/Theguael/dataviz/blob/master/rendu/simple-d3-js.pdf">Rendu intermédiaire (pdf)</a>
 - <a href="">Article final (pdf)</a>
 - <a href="https://github.com/Theguael/dataviz/wiki">Cahier d'avancement</a>


### PR DESCRIPTION
Le lien vers la page publique était érroné.
Désolé pour le dérangement.